### PR TITLE
Update Gyazo upload endpoint URI

### DIFF
--- a/app/src/main/java/xtuaok/sharegyazo/ProfileListFragment.java
+++ b/app/src/main/java/xtuaok/sharegyazo/ProfileListFragment.java
@@ -87,7 +87,7 @@ public class ProfileListFragment extends Fragment
             public void onClick(View view) {
                 final View v = view;
                 Bundle bundle = new Bundle();
-                Profile profile = new Profile("gyazo", "http://gyazo.com/upload.cgi");
+                Profile profile = new Profile("gyazo", "https://upload.gyazo.com/upload.cgi");
                 bundle.putParcelable(Profile.EXTRA_PROFILE, profile);
                 bundle.putBoolean(Profile.EXTRA_NEW_PROFILE, true);
                 ProfileSettingFragment fragment = new ProfileSettingFragment();

--- a/app/src/main/java/xtuaok/sharegyazo/ProfileManager.java
+++ b/app/src/main/java/xtuaok/sharegyazo/ProfileManager.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 public class ProfileManager {
     private static final String LOG_TAG = "ProfileManager";
 
-    private static final String PRESET_URL = "http://gyazo.com/upload.cgi";
+    private static final String PRESET_URL = "https://upload.gyazo.com/upload.cgi";
     private static final String PRESET_NAME = "Gyazo";
 
     private static final String PREF_PROFILES = "profile_list";

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -70,7 +70,7 @@
 
     <string name="cgi_url_dialog_title">Gyazo CGI URL</string>
     <string name="cgi_url_dialog_message">Gyazo CGIのURLを入力してください</string>
-    <string name="cgi_url_dialog_hint">http://gyazo.com/upload.cgi</string>
+    <string name="cgi_url_dialog_hint">https://upload.gyazo.com/upload.cgi</string>
 
     <string name="gyazo_id_dialog_title">Gyazo ID</string>
     <string name="gyazo_id_dialog_message">GyazoIDを入力してください</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,7 +69,7 @@
 
     <string name="cgi_url_dialog_title">Gyazo CGI URL</string>
     <string name="cgi_url_dialog_message">Enter a Gyazo CGI URL</string>
-    <string name="cgi_url_dialog_hint">http://gyazo.com/upload.cgi</string>
+    <string name="cgi_url_dialog_hint">https://upload.gyazo.com/upload.cgi</string>
 
     <string name="gyazo_id_dialog_title">Gyazo ID</string>
     <string name="gyazo_id_dialog_message">Enter a GyazoID</string>


### PR DESCRIPTION
Old endpoint http://gyazo.com/upload.cgi was deprecated. Use new endpoint and enable SSL support.